### PR TITLE
Change default bandwidth to 1Hz from 1MHz

### DIFF
--- a/rfdesigner/simulation/__init__.py
+++ b/rfdesigner/simulation/__init__.py
@@ -8,13 +8,13 @@ def noise_floor(nf=1, bandwidth=1, noise_temp=290):
     Calculate noise floor of a receiver.
 
     :param nf: Noise figure in dB
-    :param bandwidth: bandwidth in MHz
+    :param bandwidth: bandwidth in Hz
     :param noise_temp: noise temperature in Kelvin
     """
     return (
         10 * math.log10(KBOLTZMAN * noise_temp * 1000)
         + nf
-        + 10 * math.log10(bandwidth * 1e6)
+        + 10 * math.log10(bandwidth)
     )
 
 
@@ -63,7 +63,7 @@ def cascade(system=None, pin=0, bandwidth=1, noise_temp=290):
 
     :param system: Sequential list of RF objects where position in list indicates position in signal chain. Currently mutli-branch networks not supported.
     :param pin: Input power of the system in dBm.
-    :param bandwidth: Bandwidth of input signal in MHz.
+    :param bandwidth: Bandwidth of input signal in Hz.
     :param noise_temp: Noise temperature in Kelvin.
     """
     if not system:

--- a/rfdesigner/simulation/__init__.py
+++ b/rfdesigner/simulation/__init__.py
@@ -12,9 +12,7 @@ def noise_floor(nf=1, bandwidth=1, noise_temp=290):
     :param noise_temp: noise temperature in Kelvin
     """
     return (
-        10 * math.log10(KBOLTZMAN * noise_temp * 1000)
-        + nf
-        + 10 * math.log10(bandwidth)
+        10 * math.log10(KBOLTZMAN * noise_temp * 1000) + nf + 10 * math.log10(bandwidth)
     )
 
 

--- a/tests/test_simulation/test_sim_init.py
+++ b/tests/test_simulation/test_sim_init.py
@@ -73,5 +73,5 @@ class TestCascade(unittest.TestCase):
 
     def test_noise_floor(self):
         """Test the noise floor method."""
-        result = sim.noise_floor(nf=0, bandwidth=1e-6, noise_temp=290)
+        result = sim.noise_floor(nf=0, bandwidth=1, noise_temp=290)
         self.assertEqual(round(result), -174)


### PR DESCRIPTION
## Description:
Updates noise floor calculation to use 1Hz bandwidth by default instead of 1MHz

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
