### PR TITLE
Add IM3 and SFDR calculations

### DIFF
--- a/rfdesigner/components/__init__.py
+++ b/rfdesigner/components/__init__.py
@@ -239,6 +239,11 @@ class Generic:
         self._iip3 = RFSignal(value, units="dBm")
 
     @property
+    def total_im3(self):
+        """Get the im3 value."""
+        return 2 * (self.total_gain + self.total_iip3 - self.pout)
+
+    @property
     def total_gain(self):
         """Get total gain value."""
         return self._total_gain

--- a/rfdesigner/simulation/__init__.py
+++ b/rfdesigner/simulation/__init__.py
@@ -85,6 +85,7 @@ def cascade(system=None, pin=0, bandwidth=1, noise_temp=290):
     total_oip3 = total_iip3 + total_gain
     mds = noise_floor(nf=total_nf, bandwidth=bandwidth, noise_temp=noise_temp)
     snr = pin - mds - total_nf
+    sfdr = 2 / 3 * (total_iip3 - mds)
 
     results = {
         "pin": pin,
@@ -95,6 +96,7 @@ def cascade(system=None, pin=0, bandwidth=1, noise_temp=290):
         "oip3": total_oip3,
         "p1db": total_p1db,
         "snr": snr,
+        "sfdr": sfdr,
         "mds": mds,
     }
     return results


### PR DESCRIPTION
## Description:
Adds `total_im3` calculation to components and an `sfdr` calculation during cascade.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
